### PR TITLE
Fixed exceprion occurred when filenames contain russian letters

### DIFF
--- a/lib/pyrrent2http/util.py
+++ b/lib/pyrrent2http/util.py
@@ -56,7 +56,7 @@ def encode_msg(msg):
 def localize_path(path):
     if not isinstance(path, unicode): path = path.decode(chardet.detect(path)['encoding'])
     if not sys.platform.startswith('win'):
-        path = path.encode(sys.getfilesystemencoding() != 'ascii' and sys.getfilesystemencoding() or 'utf-8')
+        path = path.encode((sys.getfilesystemencoding() not in ('ascii', 'ANSI_X3.4-1968')) and sys.getfilesystemencoding() or 'utf-8')
     return path
 
 def can_bind(host, port):


### PR DESCRIPTION
I have a problem with opening .torrent files which contains filenames or directories containing russian letters. The kodi log looks like this:

```
1:22:11 380209.312500 T:1481634800  NOTICE: [pyrrent2http] INFO: Setting Everybody.Hates.Chris.S03.720p.WEB-DL.Кураж-Бамбей/Everybody.Hates.Chris.S03E11.Everybody.Hates.The.Port.Authority.720p.WEB-DL.DD5.1.H264.mkv priority to 0
21:22:11 380209.312500 T:1481634800  NOTICE: [pyrrent2http] INFO: Starting HTTP Server...
21:22:11 380209.312500 T:1481634800  NOTICE: [pyrrent2http] INFO: Listening HTTP on 127.0.0.1:55353...
21:22:11 380209.437500 T:1481634800  NOTICE: [pyrrent2http] pyrrent2http successfully started.
21:22:11 380209.437500 T:1481634800   DEBUG: ### [Torrenter v.2.5.3]: [setup_nextep]: not url2
21:22:11 380209.468750 T:1481634800  NOTICE: ### [Torrenter v.2.5.3]: [InposPlayer]: next_dl - False, next_play - False, ids_video - None
21:22:11 380209.531250 T:1481634800  NOTICE: ### [Torrenter v.2.5.3]: Traceback (most recent call last):
                                              File "/home/osmc/.kodi/addons/plugin.video.torrenter/Inposloader.py", line 255, in __init__
                                                self.engine.activate_file(self.contentId)
                                              File "/home/osmc/.kodi/addons/script.module.pyrrent2http/lib/pyrrent2http/engine.py", line 249, in activate_file
                                                self.pyrrent2http.TorrentFS.file(index)
                                              File "/home/osmc/.kodi/addons/script.module.pyrrent2http/lib/pyrrent2http/pyrrent2http.py", line 304, in file
                                                file_ = self.__file_at_(index)
                                              File "/home/osmc/.kodi/addons/script.module.pyrrent2http/lib/pyrrent2http/pyrrent2http.py", line 366, in __file_at_
                                                path = os.path.abspath(os.path.join(self.save_path, localize_path(fe_path)))
                                              File "/home/osmc/.kodi/addons/script.module.pyrrent2http/lib/pyrrent2http/util.py", line 59, in localize_path
                                                path = path.encode(sys.getfilesystemencoding() != 'ascii' and sys.getfilesystemencoding() or 'utf-8')
                                            UnicodeEncodeError: 'ascii' codec can't encode characters in position 38-42: ordinal not in range(128)
21:22:11 380209.531250 T:1481634800  NOTICE: [pyrrent2http] Shutting down pyrrent2http...
```

I'm running kodi on OSMC on RPi2
```
>>> sys.getfilesystemencoding()
'ANSI_X3.4-1968'
>>> sys.platform
'linux2'
>>>
```

These changes are tested and there's no more error on my platform. Please consider adding it to the repo or fix the problem otherwise